### PR TITLE
Redmine 19052 appointmentsearch does not support the option to book appointments without multislots

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/modules/solr/service/SlotUtil.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/modules/solr/service/SlotUtil.java
@@ -151,12 +151,13 @@ public final class SlotUtil
         item.addDynamicField( MINUTE_OF_DAY,
                 ChronoUnit.MINUTES.between( slot.getStartingDateTime( ).toLocalDate( ).atStartOfDay( ), slot.getStartingDateTime( ) ) );
 
-        if(appointmentForm.getIsMultislotAppointment() ) {
-            if (calculateConsecutiveSlots(slot, allSlots) <= appointmentForm.getNbConsecutiveSlots()) {
-                item.addDynamicField(NB_CONSECUTIVES_SLOTS, (long) calculateConsecutiveSlots(slot, allSlots));
+        long consecutiveSlots = calculateConsecutiveSlots(slot, allSlots);
+        if (appointmentForm.getIsMultislotAppointment()) {
+            if (consecutiveSlots <= appointmentForm.getNbConsecutiveSlots()) {
+                item.addDynamicField(NB_CONSECUTIVES_SLOTS, consecutiveSlots);
             }
-        }else {
-            item.addDynamicField( NB_CONSECUTIVES_SLOTS, 1L  );
+        } else {
+            item.addDynamicField(NB_CONSECUTIVES_SLOTS, 1L);
         }
 
         // Date Hierarchy

--- a/src/java/fr/paris/lutece/plugins/appointment/modules/solr/service/SlotUtil.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/modules/solr/service/SlotUtil.java
@@ -150,7 +150,14 @@ public final class SlotUtil
         item.addDynamicField( DAY_OF_WEEK, Long.valueOf( slot.getStartingDateTime( ).getDayOfWeek( ).getValue( ) ) );
         item.addDynamicField( MINUTE_OF_DAY,
                 ChronoUnit.MINUTES.between( slot.getStartingDateTime( ).toLocalDate( ).atStartOfDay( ), slot.getStartingDateTime( ) ) );
-        item.addDynamicField( NB_CONSECUTIVES_SLOTS, (long) calculateConsecutiveSlots( slot, allSlots ) );
+
+        if(appointmentForm.getIsMultislotAppointment() ) {
+            if (calculateConsecutiveSlots(slot, allSlots) <= appointmentForm.getNbConsecutiveSlots()) {
+                item.addDynamicField(NB_CONSECUTIVES_SLOTS, (long) calculateConsecutiveSlots(slot, allSlots));
+            }
+        }else {
+            item.addDynamicField( NB_CONSECUTIVES_SLOTS, 1L  );
+        }
 
         // Date Hierarchy
         item.setHieDate( slot.getStartingDateTime( ).toLocalDate( ).format( Utilities.HIE_DATE_FORMATTER ) );


### PR DESCRIPTION
Redmine issue : [Evolution 1952](https://dev.lutece.paris.fr/bugtracker/issues/19052 )

Please note that [PR101](https://github.com/lutece-secteur-public/gru-plugin-appointment/pull/101 ) must be merged first as it contains essential changes that are required for proper functionality. 
Thanks!